### PR TITLE
Refactor publish pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,8 +4,25 @@ on:
   workflow_dispatch:
 
 jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Java JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: temurin
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+      - name: Build
+        run: ./gradlew assembleRelease --scan
+
   publish-github:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
+    environment: github
+    needs: build
     permissions:
       contents: read
       packages: write
@@ -20,18 +37,17 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
       - name: Build
-        run: ./gradlew publishAllPublicationsToGithubRepository --scan
+        run: ./gradlew publishAllPublicationsToGithubRepository --scan -Dorg.gradle.parallel=false
         env:
-          PUBLISHING: true
           ORG_GRADLE_PROJECT_githubUsername: boswelja
           ORG_GRADLE_PROJECT_githubToken: ${{ secrets.GITHUB_TOKEN }}
-          ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.OSSRH_USERNAME }}
-          ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.OSSRH_PASSWORD }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
 
   publish-oss:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
+    environment: mavencentral
+    needs: build
     permissions:
       contents: read
       packages: write
@@ -46,18 +62,16 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
       - name: Build
-        run: ./gradlew publishAllPublicationsToOssRepository --scan
+        run: ./gradlew publishAllPublicationsToOssRepository --scan -Dorg.gradle.parallel=false
         env:
           PUBLISHING: true
-          ORG_GRADLE_PROJECT_githubUsername: boswelja
-          ORG_GRADLE_PROJECT_githubToken: ${{ secrets.GITHUB_TOKEN }}
           ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.OSSRH_USERNAME }}
           ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.OSSRH_PASSWORD }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
 
-  upload-pages:
-    runs-on: ubuntu-latest
+  build-pages:
+    runs-on: macos-latest
     needs:
       - publish-github
       - publish-oss
@@ -79,7 +93,7 @@ jobs:
           path: "build/dokka/htmlMultiModule/"
 
   deploy-pages:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     needs: upload-pages
     permissions:
       pages: write

--- a/bitrate/build.gradle.kts
+++ b/bitrate/build.gradle.kts
@@ -78,19 +78,21 @@ signing {
 
 publishing {
     repositories {
-        if (System.getenv("PUBLISHING") == "true") {
+        val githubUsername = findProperty("githubUsername")?.toString()
+        val githubToken = findProperty("githubToken")?.toString()
+        if (githubUsername != null && githubToken != null) {
             maven("https://maven.pkg.github.com/boswelja/kotlin-datatypes") {
-                val githubUsername: String? by project.properties
-                val githubToken: String? by project.properties
                 name = "github"
                 credentials {
                     username = githubUsername
                     password = githubToken
                 }
             }
+        }
+        val ossrhUsername = findProperty("ossrhUsername")?.toString()
+        val ossrhPassword = findProperty("ossrhPassword")?.toString()
+        if (ossrhUsername != null && ossrhPassword != null) {
             maven("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/") {
-                val ossrhUsername: String? by project
-                val ossrhPassword: String? by project
                 name = "oss"
                 credentials {
                     username = ossrhUsername

--- a/capacity/build.gradle.kts
+++ b/capacity/build.gradle.kts
@@ -78,19 +78,21 @@ signing {
 
 publishing {
     repositories {
-        if (System.getenv("PUBLISHING") == "true") {
+        val githubUsername = findProperty("githubUsername")?.toString()
+        val githubToken = findProperty("githubToken")?.toString()
+        if (githubUsername != null && githubToken != null) {
             maven("https://maven.pkg.github.com/boswelja/kotlin-datatypes") {
-                val githubUsername: String? by project.properties
-                val githubToken: String? by project.properties
                 name = "github"
                 credentials {
                     username = githubUsername
                     password = githubToken
                 }
             }
+        }
+        val ossrhUsername = findProperty("ossrhUsername")?.toString()
+        val ossrhPassword = findProperty("ossrhPassword")?.toString()
+        if (ossrhUsername != null && ossrhPassword != null) {
             maven("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/") {
-                val ossrhUsername: String? by project
-                val ossrhPassword: String? by project
                 name = "oss"
                 credentials {
                     username = ossrhUsername

--- a/percentage/build.gradle.kts
+++ b/percentage/build.gradle.kts
@@ -69,19 +69,21 @@ signing {
 
 publishing {
     repositories {
-        if (System.getenv("PUBLISHING") == "true") {
+        val githubUsername = findProperty("githubUsername")?.toString()
+        val githubToken = findProperty("githubToken")?.toString()
+        if (githubUsername != null && githubToken != null) {
             maven("https://maven.pkg.github.com/boswelja/kotlin-datatypes") {
-                val githubUsername: String? by project.properties
-                val githubToken: String? by project.properties
                 name = "github"
                 credentials {
                     username = githubUsername
                     password = githubToken
                 }
             }
+        }
+        val ossrhUsername = findProperty("ossrhUsername")?.toString()
+        val ossrhPassword = findProperty("ossrhPassword")?.toString()
+        if (ossrhUsername != null && ossrhPassword != null) {
             maven("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/") {
-                val ossrhUsername: String? by project
-                val ossrhPassword: String? by project
                 name = "oss"
                 credentials {
                     username = ossrhUsername

--- a/percentage/build.gradle.kts
+++ b/percentage/build.gradle.kts
@@ -60,6 +60,13 @@ detekt {
     basePath = rootDir.absolutePath
 }
 
+signing {
+    val signingKey: String? by project
+    val signingPassword: String? by project
+    useInMemoryPgpKeys(signingKey, signingPassword)
+    sign(publishing.publications)
+}
+
 publishing {
     repositories {
         if (System.getenv("PUBLISHING") == "true") {

--- a/temperature/build.gradle.kts
+++ b/temperature/build.gradle.kts
@@ -61,6 +61,13 @@ detekt {
     basePath = rootDir.absolutePath
 }
 
+signing {
+    val signingKey: String? by project
+    val signingPassword: String? by project
+    useInMemoryPgpKeys(signingKey, signingPassword)
+    sign(publishing.publications)
+}
+
 publishing {
     repositories {
         if (System.getenv("PUBLISHING") == "true") {

--- a/temperature/build.gradle.kts
+++ b/temperature/build.gradle.kts
@@ -70,19 +70,21 @@ signing {
 
 publishing {
     repositories {
-        if (System.getenv("PUBLISHING") == "true") {
+        val githubUsername = findProperty("githubUsername")?.toString()
+        val githubToken = findProperty("githubToken")?.toString()
+        if (githubUsername != null && githubToken != null) {
             maven("https://maven.pkg.github.com/boswelja/kotlin-datatypes") {
-                val githubUsername: String? by project.properties
-                val githubToken: String? by project.properties
                 name = "github"
                 credentials {
                     username = githubUsername
                     password = githubToken
                 }
             }
+        }
+        val ossrhUsername = findProperty("ossrhUsername")?.toString()
+        val ossrhPassword = findProperty("ossrhPassword")?.toString()
+        if (ossrhUsername != null && ossrhPassword != null) {
             maven("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/") {
-                val ossrhUsername: String? by project
-                val ossrhPassword: String? by project
                 name = "oss"
                 credentials {
                     username = ossrhUsername


### PR DESCRIPTION
- Build is a separate step to help deal with non-parallel publishing
- GH and central use separate deployment environments. This keeps their credentials separate (and gives us a nice overview on the GH landing page)
- Changed the conditions for enabling repositories
- Publish is run on macos