### PR TITLE
Deprecate toLong and toDouble in favor of more descriptive functions

### DIFF
--- a/bitrate/src/commonMain/kotlin/com/boswelja/bitrate/Bitrate.kt
+++ b/bitrate/src/commonMain/kotlin/com/boswelja/bitrate/Bitrate.kt
@@ -38,6 +38,7 @@ value class Bitrate internal constructor(private val rawValue: Long) : Comparabl
      * Converts this Bitrate to the given [BitrateUnit], returning a Double representing the
      * precise value.
      */
+    @Deprecated("Use toFractionalUnits instead", ReplaceWith("toFractionalUnits(unit)"))
     fun toDouble(unit: BitrateUnit): Double {
         return rawValue.toDouble() / unit.bitFactor
     }
@@ -45,8 +46,30 @@ value class Bitrate internal constructor(private val rawValue: Long) : Comparabl
     /**
      * Converts this Bitrate to the given [BitrateUnit], rounding to the nearest whole number.
      */
+    @Deprecated("Use toWholeUnits or roundToWholeUnits instead", ReplaceWith("roundToWholeUnits(unit)"))
     fun toLong(unit: BitrateUnit): Long {
-        return toDouble(unit).roundToLong()
+        return roundToWholeUnits(unit)
+    }
+
+    /**
+     * Converts this Capacity to the given [CapacityUnit], returning a Double representing the precise value.
+     */
+    fun toFractionalUnits(unit: BitrateUnit): Double {
+        return rawValue.toDouble() / unit.bitFactor
+    }
+
+    /**
+     * Converts this Capacity to the given [CapacityUnit], rounding down to the nearest whole number.
+     */
+    fun toWholeUnits(unit: BitrateUnit): Long {
+        return rawValue / unit.bitFactor
+    }
+
+    /**
+     * Converts this Capacity to the given [CapacityUnit], rounding to the nearest whole number.
+     */
+    fun roundToWholeUnits(unit: BitrateUnit): Long {
+        return toFractionalUnits(unit).roundToLong()
     }
 
     @Suppress("unused")

--- a/bitrate/src/commonTest/kotlin/com/boswelja/bitrate/BitrateTest.kt
+++ b/bitrate/src/commonTest/kotlin/com/boswelja/bitrate/BitrateTest.kt
@@ -12,26 +12,54 @@ import kotlin.test.assertTrue
 class BitrateTest {
 
     @Test
-    fun toLong_roundsDownCorrectly() {
+    fun roundToWholeUnits_roundsDownCorrectly() {
         assertEquals(
             1,
-            1.5.terabits.toLong(BitrateUnit.TEBIBITS)
+            1.5.terabits.roundToWholeUnits(BitrateUnit.TEBIBITS)
         )
         assertEquals(
             1,
-            1.49.terabits.toLong(BitrateUnit.TERABITS)
+            1.49.terabits.roundToWholeUnits(BitrateUnit.TERABITS)
+        )
+        assertEquals(
+            1,
+            1.01.terabits.roundToWholeUnits(BitrateUnit.TERABITS)
         )
     }
 
     @Test
-    fun toLong_roundsUpCorrectly() {
+    fun roundToWholeUnits_roundsUpCorrectly() {
         assertEquals(
             2,
-            1.5.tebibits.toLong(BitrateUnit.TERABITS)
+            1.51.terabits.roundToWholeUnits(BitrateUnit.TERABITS)
         )
         assertEquals(
             2,
-            1.5.tebibits.toLong(BitrateUnit.TERABITS)
+            1.9.terabits.roundToWholeUnits(BitrateUnit.TERABITS)
+        )
+    }
+
+    @Test
+    fun toWholeUnits_roundsCorrectly() {
+        assertEquals(
+            1,
+            1.5.terabits.toWholeUnits(BitrateUnit.TEBIBITS)
+        )
+        assertEquals(
+            1,
+            1.49.terabits.toWholeUnits(BitrateUnit.TERABITS)
+        )
+        assertEquals(
+            1,
+            1.01.terabits.toWholeUnits(BitrateUnit.TERABITS)
+        )
+        assertEquals(
+            1,
+            1.51.terabits.toWholeUnits(BitrateUnit.TERABITS)
+        )
+        assertEquals(
+            1,
+            1.9.terabits.toWholeUnits(BitrateUnit.TERABITS)
         )
     }
 

--- a/capacity/build.gradle.kts
+++ b/capacity/build.gradle.kts
@@ -1,5 +1,5 @@
 import org.jetbrains.dokka.gradle.DokkaTaskPartial
-import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import java.net.URL
 
 plugins {

--- a/capacity/src/commonMain/kotlin/com/boswelja/capacity/Capacity.kt
+++ b/capacity/src/commonMain/kotlin/com/boswelja/capacity/Capacity.kt
@@ -17,6 +17,12 @@ import kotlin.math.roundToLong
 @JvmInline
 value class Capacity internal constructor(private val rawValue: Long) : Comparable<Capacity> {
 
+    /**
+     * Returns the value of this Capacity in bytes.
+     */
+    val inWholeBytes: Long
+        get() = rawValue
+
     override fun compareTo(other: Capacity): Int {
         return rawValue.compareTo(other.rawValue)
     }
@@ -45,18 +51,18 @@ value class Capacity internal constructor(private val rawValue: Long) : Comparab
     }
 
     /**
-     * Converts this Capacity to the given [CapacityUnit], returning a Double representing the precise value.
-     */
-    fun toFractionalUnits(unit: CapacityUnit): Double {
-        return rawValue.toDouble() / unit.byteFactor
-    }
-
-    /**
      * Converts this Capacity to the given [CapacityUnit], rounding to the nearest whole number.
      */
     @Deprecated("Use inWholeUnits or roundToWholeUnits instead", ReplaceWith("roundToWholeUnits(unit)"))
     fun toLong(unit: CapacityUnit): Long {
         return toFractionalUnits(unit).roundToLong()
+    }
+
+    /**
+     * Converts this Capacity to the given [CapacityUnit], returning a Double representing the precise value.
+     */
+    fun toFractionalUnits(unit: CapacityUnit): Double {
+        return rawValue.toDouble() / unit.byteFactor
     }
 
     /**

--- a/capacity/src/commonMain/kotlin/com/boswelja/capacity/Capacity.kt
+++ b/capacity/src/commonMain/kotlin/com/boswelja/capacity/Capacity.kt
@@ -41,13 +41,13 @@ value class Capacity internal constructor(private val rawValue: Long) : Comparab
      */
     @Deprecated("Use inFractionalUnits instead", ReplaceWith("inFractionalUnits(unit)"))
     fun toDouble(unit: CapacityUnit): Double {
-        return inFractionalUnits(unit)
+        return toFractionalUnits(unit)
     }
 
     /**
      * Converts this Capacity to the given [CapacityUnit], returning a Double representing the precise value.
      */
-    fun inFractionalUnits(unit: CapacityUnit): Double {
+    fun toFractionalUnits(unit: CapacityUnit): Double {
         return rawValue.toDouble() / unit.byteFactor
     }
 
@@ -56,13 +56,13 @@ value class Capacity internal constructor(private val rawValue: Long) : Comparab
      */
     @Deprecated("Use inWholeUnits or roundToWholeUnits instead", ReplaceWith("roundToWholeUnits(unit)"))
     fun toLong(unit: CapacityUnit): Long {
-        return inFractionalUnits(unit).roundToLong()
+        return toFractionalUnits(unit).roundToLong()
     }
 
     /**
      * Converts this Capacity to the given [CapacityUnit], rounding down to the nearest whole number.
      */
-    fun inWholeUnits(unit: CapacityUnit): Long {
+    fun toWholeUnits(unit: CapacityUnit): Long {
         return rawValue / unit.byteFactor
     }
 
@@ -70,7 +70,7 @@ value class Capacity internal constructor(private val rawValue: Long) : Comparab
      * Converts this Capacity to the given [CapacityUnit], rounding to the nearest whole number.
      */
     fun roundToWholeUnits(unit: CapacityUnit): Long {
-        return inFractionalUnits(unit).roundToLong()
+        return toFractionalUnits(unit).roundToLong()
     }
 
     @Suppress("unused")

--- a/capacity/src/commonMain/kotlin/com/boswelja/capacity/Capacity.kt
+++ b/capacity/src/commonMain/kotlin/com/boswelja/capacity/Capacity.kt
@@ -45,7 +45,7 @@ value class Capacity internal constructor(private val rawValue: Long) : Comparab
      * Converts this Capacity to the given [CapacityUnit], returning a Double representing the
      * precise value.
      */
-    @Deprecated("Use inFractionalUnits instead", ReplaceWith("inFractionalUnits(unit)"))
+    @Deprecated("Use toFractionalUnits instead", ReplaceWith("toFractionalUnits(unit)"))
     fun toDouble(unit: CapacityUnit): Double {
         return toFractionalUnits(unit)
     }
@@ -53,9 +53,9 @@ value class Capacity internal constructor(private val rawValue: Long) : Comparab
     /**
      * Converts this Capacity to the given [CapacityUnit], rounding to the nearest whole number.
      */
-    @Deprecated("Use inWholeUnits or roundToWholeUnits instead", ReplaceWith("roundToWholeUnits(unit)"))
+    @Deprecated("Use toWholeUnits or roundToWholeUnits instead", ReplaceWith("roundToWholeUnits(unit)"))
     fun toLong(unit: CapacityUnit): Long {
-        return toFractionalUnits(unit).roundToLong()
+        return roundToWholeUnits(unit)
     }
 
     /**

--- a/capacity/src/commonMain/kotlin/com/boswelja/capacity/Capacity.kt
+++ b/capacity/src/commonMain/kotlin/com/boswelja/capacity/Capacity.kt
@@ -39,15 +39,38 @@ value class Capacity internal constructor(private val rawValue: Long) : Comparab
      * Converts this Capacity to the given [CapacityUnit], returning a Double representing the
      * precise value.
      */
+    @Deprecated("Use inFractionalUnits instead", ReplaceWith("inFractionalUnits(unit)"))
     fun toDouble(unit: CapacityUnit): Double {
+        return inFractionalUnits(unit)
+    }
+
+    /**
+     * Converts this Capacity to the given [CapacityUnit], returning a Double representing the precise value.
+     */
+    fun inFractionalUnits(unit: CapacityUnit): Double {
         return rawValue.toDouble() / unit.byteFactor
     }
 
     /**
      * Converts this Capacity to the given [CapacityUnit], rounding to the nearest whole number.
      */
+    @Deprecated("Use inWholeUnits or roundToWholeUnits instead", ReplaceWith("roundToWholeUnits(unit)"))
     fun toLong(unit: CapacityUnit): Long {
-        return toDouble(unit).roundToLong()
+        return inFractionalUnits(unit).roundToLong()
+    }
+
+    /**
+     * Converts this Capacity to the given [CapacityUnit], rounding down to the nearest whole number.
+     */
+    fun inWholeUnits(unit: CapacityUnit): Long {
+        return rawValue / unit.byteFactor
+    }
+
+    /**
+     * Converts this Capacity to the given [CapacityUnit], rounding to the nearest whole number.
+     */
+    fun roundToWholeUnits(unit: CapacityUnit): Long {
+        return inFractionalUnits(unit).roundToLong()
     }
 
     @Suppress("unused")

--- a/capacity/src/commonTest/kotlin/com/boswelja/capacity/CapacityTest.kt
+++ b/capacity/src/commonTest/kotlin/com/boswelja/capacity/CapacityTest.kt
@@ -42,23 +42,23 @@ class CapacityTest {
     fun inWholeUnits_roundsDownCorrectly() {
         assertEquals(
             1,
-            1.5.terabytes.inWholeUnits(CapacityUnit.TEBIBYTE)
+            1.5.terabytes.toWholeUnits(CapacityUnit.TEBIBYTE)
         )
         assertEquals(
             1,
-            1.49.terabytes.inWholeUnits(CapacityUnit.TERABYTE)
+            1.49.terabytes.toWholeUnits(CapacityUnit.TERABYTE)
         )
         assertEquals(
             1,
-            1.01.terabytes.inWholeUnits(CapacityUnit.TERABYTE)
+            1.01.terabytes.toWholeUnits(CapacityUnit.TERABYTE)
         )
         assertEquals(
             1,
-            1.51.terabytes.inWholeUnits(CapacityUnit.TERABYTE)
+            1.51.terabytes.toWholeUnits(CapacityUnit.TERABYTE)
         )
         assertEquals(
             1,
-            1.9.terabytes.inWholeUnits(CapacityUnit.TERABYTE)
+            1.9.terabytes.toWholeUnits(CapacityUnit.TERABYTE)
         )
     }
 

--- a/capacity/src/commonTest/kotlin/com/boswelja/capacity/CapacityTest.kt
+++ b/capacity/src/commonTest/kotlin/com/boswelja/capacity/CapacityTest.kt
@@ -3,7 +3,6 @@ package com.boswelja.capacity
 import com.boswelja.capacity.Capacity.Companion.bytes
 import com.boswelja.capacity.Capacity.Companion.gigabytes
 import com.boswelja.capacity.Capacity.Companion.kibibytes
-import com.boswelja.capacity.Capacity.Companion.tebibytes
 import com.boswelja.capacity.Capacity.Companion.terabytes
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -12,26 +11,54 @@ import kotlin.test.assertTrue
 class CapacityTest {
 
     @Test
-    fun toLong_roundsDownCorrectly() {
+    fun roundToWholeUnits_roundsDownCorrectly() {
         assertEquals(
             1,
-            1.5.terabytes.toLong(CapacityUnit.TEBIBYTE)
+            1.5.terabytes.roundToWholeUnits(CapacityUnit.TEBIBYTE)
         )
         assertEquals(
             1,
-            1.49.terabytes.toLong(CapacityUnit.TERABYTE)
+            1.49.terabytes.roundToWholeUnits(CapacityUnit.TERABYTE)
+        )
+        assertEquals(
+            1,
+            1.01.terabytes.roundToWholeUnits(CapacityUnit.TERABYTE)
         )
     }
 
     @Test
-    fun toLong_roundsUpCorrectly() {
+    fun roundToWholeUnits_roundsUpCorrectly() {
         assertEquals(
             2,
-            1.5.tebibytes.toLong(CapacityUnit.TERABYTE)
+            1.51.terabytes.roundToWholeUnits(CapacityUnit.TERABYTE)
         )
         assertEquals(
             2,
-            1.5.terabytes.toLong(CapacityUnit.TERABYTE)
+            1.9.terabytes.roundToWholeUnits(CapacityUnit.TERABYTE)
+        )
+    }
+
+    @Test
+    fun inWholeUnits_roundsDownCorrectly() {
+        assertEquals(
+            1,
+            1.5.terabytes.inWholeUnits(CapacityUnit.TEBIBYTE)
+        )
+        assertEquals(
+            1,
+            1.49.terabytes.inWholeUnits(CapacityUnit.TERABYTE)
+        )
+        assertEquals(
+            1,
+            1.01.terabytes.inWholeUnits(CapacityUnit.TERABYTE)
+        )
+        assertEquals(
+            1,
+            1.51.terabytes.inWholeUnits(CapacityUnit.TERABYTE)
+        )
+        assertEquals(
+            1,
+            1.9.terabytes.inWholeUnits(CapacityUnit.TERABYTE)
         )
     }
 

--- a/temperature/src/commonMain/kotlin/com/boswelja/temperature/Temperature.kt
+++ b/temperature/src/commonMain/kotlin/com/boswelja/temperature/Temperature.kt
@@ -39,6 +39,7 @@ value class Temperature internal constructor(private val kelvin: BigDecimal) : C
      * Converts this Temperature to the given [TemperatureUnit], returning a Double representing the
      * precise value.
      */
+    @Deprecated("Use toFractionalUnits instead", ReplaceWith("toFractionalUnits(unit)"))
     fun toDouble(unit: TemperatureUnit): Double {
         return unit.fromKelvin(kelvin).doubleValue(exactRequired = false)
     }
@@ -46,8 +47,30 @@ value class Temperature internal constructor(private val kelvin: BigDecimal) : C
     /**
      * Converts this Temperature to the given [TemperatureUnit], rounding to the nearest whole number.
      */
+    @Deprecated("Use toWholeUnits or roundToWholeUnits instead", ReplaceWith("roundToWholeUnits(unit)"))
     fun toLong(unit: TemperatureUnit): Long {
-        return toDouble(unit).roundToLong()
+        return toFractionalUnits(unit).roundToLong()
+    }
+
+    /**
+     * Converts this Capacity to the given [TemperatureUnit], returning a Double representing the precise value.
+     */
+    fun toFractionalUnits(unit: TemperatureUnit): Double {
+        return unit.fromKelvin(kelvin).doubleValue(exactRequired = false)
+    }
+
+    /**
+     * Converts this Capacity to the given [TemperatureUnit], rounding down to the nearest whole number.
+     */
+    fun toWholeUnits(unit: TemperatureUnit): Long {
+        return unit.fromKelvin(kelvin).longValue(exactRequired = false)
+    }
+
+    /**
+     * Converts this Capacity to the given [TemperatureUnit], rounding to the nearest whole number.
+     */
+    fun roundToWholeUnits(unit: TemperatureUnit): Long {
+        return toFractionalUnits(unit).roundToLong()
     }
 
     @Suppress("unused")

--- a/temperature/src/commonTest/kotlin/com/boswelja/temperature/TemperatureTest.kt
+++ b/temperature/src/commonTest/kotlin/com/boswelja/temperature/TemperatureTest.kt
@@ -34,31 +34,31 @@ class TemperatureTest {
     )
 
     private fun testAgainstTestPoint(temperature: Temperature, testPoint: TestPoint) {
-        val convertedKelvin = temperature.toDouble(TemperatureUnit.KELVIN)
+        val convertedKelvin = temperature.toFractionalUnits(TemperatureUnit.KELVIN)
         assertEquals(
             testPoint.kelvin,
             convertedKelvin,
             "Expected ${testPoint.kelvin} K, but got $convertedKelvin K"
         )
-        val convertedCelsius = temperature.toDouble(TemperatureUnit.CELSIUS)
+        val convertedCelsius = temperature.toFractionalUnits(TemperatureUnit.CELSIUS)
         assertEquals(
             testPoint.celsius,
             convertedCelsius,
             "Expected ${testPoint.celsius} °C, but got $convertedCelsius °C"
         )
-        val convertedFahrenheit = temperature.toDouble(TemperatureUnit.FAHRENHEIT)
+        val convertedFahrenheit = temperature.toFractionalUnits(TemperatureUnit.FAHRENHEIT)
         assertEquals(
             testPoint.fahrenheit,
             convertedFahrenheit,
             "Expected ${testPoint.fahrenheit} °F, but got $convertedFahrenheit °F"
         )
-        val convertedRankine = temperature.toDouble(TemperatureUnit.RANKINE)
+        val convertedRankine = temperature.toFractionalUnits(TemperatureUnit.RANKINE)
         assertEquals(
             testPoint.rankine,
             convertedRankine,
             "Expected ${testPoint.rankine} °R, but got $convertedRankine °R"
         )
-        val convertedReaumur = temperature.toDouble(TemperatureUnit.REAUMUR)
+        val convertedReaumur = temperature.toFractionalUnits(TemperatureUnit.REAUMUR)
         assertEquals(
             testPoint.reaumur,
             convertedReaumur,


### PR DESCRIPTION
`toDouble` has become `toFractionalUnits`, and `toLong` was split into `toWholeUnits` and `roundToWholeUnits`.
The sole exception is `percentage`since it doesn't use units the whole/fractional naming doesn't make as much sense there.