### PR TITLE
Reduce extension count by extending `Number` rather than individual types

### DIFF
--- a/bitrate/src/commonMain/kotlin/com/boswelja/bitrate/Bitrate.kt
+++ b/bitrate/src/commonMain/kotlin/com/boswelja/bitrate/Bitrate.kt
@@ -104,10 +104,10 @@ value class Bitrate internal constructor(private val rawValue: Long) : Comparabl
 
         /** Converts a [Number] representation of gibibits to a [Bitrate]. */
         val Number.gibibits: Bitrate get() =  toBitrate(BitrateUnit.GIBIBITS)
-        
+
         /** Converts a [Number] representation of tebibits to a [Bitrate]. */
         val Number.tebibits: Bitrate get() =  toBitrate(BitrateUnit.TEBIBITS)
-        
+
         /** Converts a [Number] representation of pebibits to a [Bitrate]. */
         val Number.pebibits: Bitrate get() = toBitrate(BitrateUnit.PEBIBITS)
 

--- a/bitrate/src/commonMain/kotlin/com/boswelja/bitrate/Bitrate.kt
+++ b/bitrate/src/commonMain/kotlin/com/boswelja/bitrate/Bitrate.kt
@@ -75,165 +75,61 @@ value class Bitrate internal constructor(private val rawValue: Long) : Comparabl
     @Suppress("unused")
     companion object {
 
-        private fun Int.toBitrate(unit: BitrateUnit): Bitrate = Bitrate(this * unit.bitFactor)
-        private fun Long.toBitrate(unit: BitrateUnit): Bitrate = Bitrate(this * unit.bitFactor)
-        private fun Float.toBitrate(unit: BitrateUnit): Bitrate = Bitrate((this * unit.bitFactor).roundToLong())
-        private fun Double.toBitrate(unit: BitrateUnit): Bitrate = Bitrate((this * unit.bitFactor).roundToLong())
+        /**
+         * Converts a [Number] to a [Bitrate], using the given [BitrateUnit].
+         */
+        fun Number.toBitrate(unit: BitrateUnit): Bitrate {
+            return when (this) {
+                is Byte -> Bitrate(this * unit.bitFactor)
+                is Double -> Bitrate((this * unit.bitFactor).roundToLong())
+                is Float -> Bitrate((this * unit.bitFactor).roundToLong())
+                is Int -> Bitrate(this * unit.bitFactor)
+                is Long -> Bitrate(this * unit.bitFactor)
+                is Short -> Bitrate(this * unit.bitFactor)
+                else -> {
+                    // Best-effort conversion
+                    Bitrate((this.toDouble() * unit.bitFactor).roundToLong())
+                }
+            }
+        }
 
-        // region bits
-        /** Converts an [Int] representation of bits to a [Bitrate]. */
-        val Int.bits: Bitrate get() = Bitrate(toLong())
+        /** Converts a [Number] representation of bits to a [Bitrate]. */
+        val Number.bits: Bitrate get() = toBitrate(BitrateUnit.BITS)
 
-        /** Converts a [Long] representation of bits to a [Bitrate]. */
-        val Long.bits: Bitrate get() = Bitrate(this)
-        // endregion
+        /** Converts a [Number] representation of kibibits to a [Bitrate]. */
+        val Number.kibibits: Bitrate get() = toBitrate(BitrateUnit.KIBIBITS)
 
-        // region binary units
-        /** Converts an [Int] representation of kibibits to a [Bitrate]. */
-        val Int.kibibits: Bitrate get() = toBitrate(BitrateUnit.KIBIBITS)
+        /** Converts a [Number] representation of mebibits to a [Bitrate]. */
+        val Number.mebibits: Bitrate get() =  toBitrate(BitrateUnit.MEBIBITS)
 
-        /** Converts an [Int] representation of mebibits to a [Bitrate]. */
-        val Int.mebibits: Bitrate get() = toBitrate(BitrateUnit.MEBIBITS)
+        /** Converts a [Number] representation of gibibits to a [Bitrate]. */
+        val Number.gibibits: Bitrate get() =  toBitrate(BitrateUnit.GIBIBITS)
+        
+        /** Converts a [Number] representation of tebibits to a [Bitrate]. */
+        val Number.tebibits: Bitrate get() =  toBitrate(BitrateUnit.TEBIBITS)
+        
+        /** Converts a [Number] representation of pebibits to a [Bitrate]. */
+        val Number.pebibits: Bitrate get() = toBitrate(BitrateUnit.PEBIBITS)
 
-        /** Converts an [Int] representation of gibibits to a [Bitrate]. */
-        val Int.gibibits: Bitrate get() = toBitrate(BitrateUnit.GIBIBITS)
+        /** Converts a [Number] representation of exibits to a [Bitrate]. */
+        val Number.exbibits: Bitrate get() = toBitrate(BitrateUnit.EXBIBITS)
 
-        /** Converts an [Int] representation of tebibits to a [Bitrate]. */
-        val Int.tebibits: Bitrate get() = toBitrate(BitrateUnit.TEBIBITS)
+        /** Converts a [Number] representation of kilobits to a [Bitrate]. */
+        val Number.kilobits: Bitrate get() = toBitrate(BitrateUnit.KILOBITS)
 
-        /** Converts an [Int] representation of pebibits to a [Bitrate]. */
-        val Int.pebibits: Bitrate get() = toBitrate(BitrateUnit.PEBIBITS)
+        /** Converts a [Number] representation of megabits to a [Bitrate]. */
+        val Number.megabits: Bitrate get() = toBitrate(BitrateUnit.MEGABITS)
 
-        /** Converts an [Int] representation of exibits to a [Bitrate]. */
-        val Int.exbibits: Bitrate get() = toBitrate(BitrateUnit.EXBIBITS)
+        /** Converts a [Number] representation of gigabits to a [Bitrate]. */
+        val Number.gigabits: Bitrate get() = toBitrate(BitrateUnit.GIGABITS)
 
-        /** Converts a [Long] representation of kibibits to a [Bitrate]. */
-        val Long.kibibits: Bitrate get() = toBitrate(BitrateUnit.KIBIBITS)
+        /** Converts a [Number] representation of terabits to a [Bitrate]. */
+        val Number.terabits: Bitrate get() = toBitrate(BitrateUnit.TERABITS)
 
-        /** Converts a [Long] representation of mebibits to a [Bitrate]. */
-        val Long.mebibits: Bitrate get() = toBitrate(BitrateUnit.MEBIBITS)
+        /** Converts a [Number] representation of petabits to a [Bitrate]. */
+        val Number.petabits: Bitrate get() = toBitrate(BitrateUnit.PETABITS)
 
-        /** Converts a [Long] representation of gibibits to a [Bitrate]. */
-        val Long.gibibits: Bitrate get() = toBitrate(BitrateUnit.GIBIBITS)
-
-        /** Converts a [Long] representation of tebibits to a [Bitrate]. */
-        val Long.tebibits: Bitrate get() = toBitrate(BitrateUnit.TEBIBITS)
-
-        /** Converts a [Long] representation of pebibits to a [Bitrate]. */
-        val Long.pebibits: Bitrate get() = toBitrate(BitrateUnit.PEBIBITS)
-
-        /** Converts a [Long] representation of exibits to a [Bitrate]. */
-        val Long.exbibits: Bitrate get() = toBitrate(BitrateUnit.EXBIBITS)
-
-        /** Converts a [Float] representation of kibibits to a [Bitrate]. */
-        val Float.kibibits: Bitrate get() = toBitrate(BitrateUnit.KIBIBITS)
-
-        /** Converts a [Float] representation of mebibits to a [Bitrate]. */
-        val Float.mebibits: Bitrate get() = toBitrate(BitrateUnit.MEBIBITS)
-
-        /** Converts a [Float] representation of gibibits to a [Bitrate]. */
-        val Float.gibibits: Bitrate get() = toBitrate(BitrateUnit.GIBIBITS)
-
-        /** Converts a [Float] representation of tebibits to a [Bitrate]. */
-        val Float.tebibits: Bitrate get() = toBitrate(BitrateUnit.TEBIBITS)
-
-        /** Converts a [Float] representation of pebibits to a [Bitrate]. */
-        val Float.pebibits: Bitrate get() = toBitrate(BitrateUnit.PEBIBITS)
-
-        /** Converts a [Float] representation of exibits to a [Bitrate]. */
-        val Float.exbibits: Bitrate get() = toBitrate(BitrateUnit.EXBIBITS)
-
-        /** Converts a [Double] representation of kibibits to a [Bitrate]. */
-        val Double.kibibits: Bitrate get() = toBitrate(BitrateUnit.KIBIBITS)
-
-        /** Converts a [Double] representation of mebibits to a [Bitrate]. */
-        val Double.mebibits: Bitrate get() = toBitrate(BitrateUnit.MEBIBITS)
-
-        /** Converts a [Double] representation of gibibits to a [Bitrate]. */
-        val Double.gibibits: Bitrate get() = toBitrate(BitrateUnit.GIBIBITS)
-
-        /** Converts a [Double] representation of tebibits to a [Bitrate]. */
-        val Double.tebibits: Bitrate get() = toBitrate(BitrateUnit.TEBIBITS)
-
-        /** Converts a [Double] representation of pebibits to a [Bitrate]. */
-        val Double.pebibits: Bitrate get() = toBitrate(BitrateUnit.PEBIBITS)
-
-        /** Converts a [Double] representation of exbibits to a [Bitrate]. */
-        val Double.exbibits: Bitrate get() = toBitrate(BitrateUnit.EXBIBITS)
-        //endregion
-
-        // region decimal units
-        /** Converts an [Int] representation of kilobits to a [Bitrate]. */
-        val Int.kilobits: Bitrate get() = toBitrate(BitrateUnit.KILOBITS)
-
-        /** Converts an [Int] representation of megabits to a [Bitrate]. */
-        val Int.megabits: Bitrate get() = toBitrate(BitrateUnit.MEGABITS)
-
-        /** Converts an [Int] representation of gigabits to a [Bitrate]. */
-        val Int.gigabits: Bitrate get() = toBitrate(BitrateUnit.GIGABITS)
-
-        /** Converts an [Int] representation of terabits to a [Bitrate]. */
-        val Int.terabits: Bitrate get() = toBitrate(BitrateUnit.TERABITS)
-
-        /** Converts an [Int] representation of petabits to a [Bitrate]. */
-        val Int.petabits: Bitrate get() = toBitrate(BitrateUnit.PETABITS)
-
-        /** Converts an [Int] representation of exabits to a [Bitrate]. */
-        val Int.exabits: Bitrate get() = toBitrate(BitrateUnit.EXABITS)
-
-        /** Converts a [Long] representation of kilobits to a [Bitrate]. */
-        val Long.kilobits: Bitrate get() = toBitrate(BitrateUnit.KILOBITS)
-
-        /** Converts a [Long] representation of megabits to a [Bitrate]. */
-        val Long.megabits: Bitrate get() = toBitrate(BitrateUnit.MEGABITS)
-
-        /** Converts a [Long] representation of gigabits to a [Bitrate]. */
-        val Long.gigabits: Bitrate get() = toBitrate(BitrateUnit.GIGABITS)
-
-        /** Converts a [Long] representation of terabits to a [Bitrate]. */
-        val Long.terabits: Bitrate get() = toBitrate(BitrateUnit.TERABITS)
-
-        /** Converts a [Long] representation of petabits to a [Bitrate]. */
-        val Long.petabits: Bitrate get() = toBitrate(BitrateUnit.PETABITS)
-
-        /** Converts a [Long] representation of exabits to a [Bitrate]. */
-        val Long.exabits: Bitrate get() = toBitrate(BitrateUnit.EXABITS)
-
-        /** Converts a [Float] representation of kilobits to a [Bitrate]. */
-        val Float.kilobits: Bitrate get() = toBitrate(BitrateUnit.KILOBITS)
-
-        /** Converts a [Float] representation of megabits to a [Bitrate]. */
-        val Float.megabits: Bitrate get() = toBitrate(BitrateUnit.MEGABITS)
-
-        /** Converts a [Float] representation of gigabits to a [Bitrate]. */
-        val Float.gigabits: Bitrate get() = toBitrate(BitrateUnit.GIGABITS)
-
-        /** Converts a [Float] representation of terabits to a [Bitrate]. */
-        val Float.terabits: Bitrate get() = toBitrate(BitrateUnit.TERABITS)
-
-        /** Converts a [Float] representation of petabits to a [Bitrate]. */
-        val Float.petabits: Bitrate get() = toBitrate(BitrateUnit.PETABITS)
-
-        /** Converts a [Float] representation of exabits to a [Bitrate]. */
-        val Float.exabits: Bitrate get() = toBitrate(BitrateUnit.EXABITS)
-
-        /** Converts a [Double] representation of kilobits to a [Bitrate]. */
-        val Double.kilobits: Bitrate get() = toBitrate(BitrateUnit.KILOBITS)
-
-        /** Converts a [Double] representation of megabits to a [Bitrate]. */
-        val Double.megabits: Bitrate get() = toBitrate(BitrateUnit.MEGABITS)
-
-        /** Converts a [Double] representation of gigabits to a [Bitrate]. */
-        val Double.gigabits: Bitrate get() = toBitrate(BitrateUnit.GIGABITS)
-
-        /** Converts a [Double] representation of terabits to a [Bitrate]. */
-        val Double.terabits: Bitrate get() = toBitrate(BitrateUnit.TERABITS)
-
-        /** Converts a [Double] representation of petabits to a [Bitrate]. */
-        val Double.petabits: Bitrate get() = toBitrate(BitrateUnit.PETABITS)
-
-        /** Converts a [Double] representation of exabits to a [Bitrate]. */
-        val Double.exabits: Bitrate get() = toBitrate(BitrateUnit.EXABITS)
-        //endregion
+        /** Converts a [Number] representation of exabits to a [Bitrate]. */
+        val Number.exabits: Bitrate get() = toBitrate(BitrateUnit.EXABITS)
     }
 }

--- a/bitrate/src/commonTest/kotlin/com/boswelja/bitrate/BitrateTest.kt
+++ b/bitrate/src/commonTest/kotlin/com/boswelja/bitrate/BitrateTest.kt
@@ -3,7 +3,6 @@ package com.boswelja.bitrate
 import com.boswelja.bitrate.Bitrate.Companion.bits
 import com.boswelja.bitrate.Bitrate.Companion.gigabits
 import com.boswelja.bitrate.Bitrate.Companion.kibibits
-import com.boswelja.bitrate.Bitrate.Companion.tebibits
 import com.boswelja.bitrate.Bitrate.Companion.terabits
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/capacity/src/commonMain/kotlin/com/boswelja/capacity/Capacity.kt
+++ b/capacity/src/commonMain/kotlin/com/boswelja/capacity/Capacity.kt
@@ -82,165 +82,61 @@ value class Capacity internal constructor(private val rawValue: Long) : Comparab
     @Suppress("unused")
     companion object {
 
-        private fun Int.toCapacity(unit: CapacityUnit): Capacity = Capacity(this * unit.byteFactor)
-        private fun Long.toCapacity(unit: CapacityUnit): Capacity = Capacity(this * unit.byteFactor)
-        private fun Float.toCapacity(unit: CapacityUnit): Capacity = Capacity((this * unit.byteFactor).roundToLong())
-        private fun Double.toCapacity(unit: CapacityUnit): Capacity = Capacity((this * unit.byteFactor).roundToLong())
+        /**
+         * Converts a [Number] to a [Capacity], using the given [CapacityUnit].
+         */
+        fun Number.toCapacity(unit: CapacityUnit): Capacity {
+            return when (this) {
+                is Byte -> Capacity(this * unit.byteFactor)
+                is Double -> Capacity((this * unit.byteFactor).roundToLong())
+                is Float -> Capacity((this * unit.byteFactor).roundToLong())
+                is Int -> Capacity(this * unit.byteFactor)
+                is Long -> Capacity(this * unit.byteFactor)
+                is Short -> Capacity(this * unit.byteFactor)
+                else -> {
+                    // Best-effort conversion
+                    Capacity((this.toDouble() * unit.byteFactor).roundToLong())
+                }
+            }
+        }
 
-        // region bytes
-        /** Converts an [Int] representation of bytes to a [Capacity]. */
-        val Int.bytes: Capacity get() = Capacity(toLong())
+        /** Converts a [Number] representation of bytes to a [Capacity]. */
+        val Number.bytes: Capacity get() = toCapacity(CapacityUnit.BYTE)
 
-        /** Converts a [Long] representation of bytes to a [Capacity]. */
-        val Long.bytes: Capacity get() = Capacity(this)
-        // endregion
+        /** Converts a [Number] representation of kibibytes to a [Capacity]. */
+        val Number.kibibytes: Capacity get() = toCapacity(CapacityUnit.KIBIBYTE)
 
-        // region binary units
-        /** Converts an [Int] representation of kibibytes to a [Capacity]. */
-        val Int.kibibytes: Capacity get() = toCapacity(CapacityUnit.KIBIBYTE)
+        /** Converts a [Number] representation of mebibytes to a [Capacity]. */
+        val Number.mebibytes: Capacity get() = toCapacity(CapacityUnit.MEBIBYTE)
 
-        /** Converts an [Int] representation of mebibytes to a [Capacity]. */
-        val Int.mebibytes: Capacity get() = toCapacity(CapacityUnit.MEBIBYTE)
+        /** Converts a [Number] representation of gibibytes to a [Capacity]. */
+        val Number.gibibytes: Capacity get() = toCapacity(CapacityUnit.GIBIBYTE)
 
-        /** Converts an [Int] representation of gibibytes to a [Capacity]. */
-        val Int.gibibytes: Capacity get() = toCapacity(CapacityUnit.GIBIBYTE)
+        /** Converts a [Number] representation of tebibytes to a [Capacity]. */
+        val Number.tebibytes: Capacity get() = toCapacity(CapacityUnit.TEBIBYTE)
 
-        /** Converts an [Int] representation of tebibytes to a [Capacity]. */
-        val Int.tebibytes: Capacity get() = toCapacity(CapacityUnit.TEBIBYTE)
+        /** Converts a [Number] representation of pebibytes to a [Capacity]. */
+        val Number.pebibytes: Capacity get() = toCapacity(CapacityUnit.PEBIBYTE)
 
-        /** Converts an [Int] representation of pebibytes to a [Capacity]. */
-        val Int.pebibytes: Capacity get() = toCapacity(CapacityUnit.PEBIBYTE)
+        /** Converts a [Number] representation of exibytes to a [Capacity]. */
+        val Number.exbibytes: Capacity get() = toCapacity(CapacityUnit.EXBIBYTE)
 
-        /** Converts an [Int] representation of exibytes to a [Capacity]. */
-        val Int.exbibytes: Capacity get() = toCapacity(CapacityUnit.EXBIBYTE)
+        /** Converts a [Number] representation of kilobytes to a [Capacity]. */
+        val Number.kilobytes: Capacity get() = toCapacity(CapacityUnit.KILOBYTE)
 
-        /** Converts a [Long] representation of kibibytes to a [Capacity]. */
-        val Long.kibibytes: Capacity get() = toCapacity(CapacityUnit.KIBIBYTE)
+        /** Converts a [Number] representation of megabytes to a [Capacity]. */
+        val Number.megabytes: Capacity get() = toCapacity(CapacityUnit.MEGABYTE)
 
-        /** Converts a [Long] representation of mebibytes to a [Capacity]. */
-        val Long.mebibytes: Capacity get() = toCapacity(CapacityUnit.MEBIBYTE)
+        /** Converts a [Number] representation of gigabytes to a [Capacity]. */
+        val Number.gigabytes: Capacity get() = toCapacity(CapacityUnit.GIGABYTE)
 
-        /** Converts a [Long] representation of gibibytes to a [Capacity]. */
-        val Long.gibibytes: Capacity get() = toCapacity(CapacityUnit.GIBIBYTE)
+        /** Converts a [Number] representation of terabytes to a [Capacity]. */
+        val Number.terabytes: Capacity get() = toCapacity(CapacityUnit.TERABYTE)
 
-        /** Converts a [Long] representation of tebibytes to a [Capacity]. */
-        val Long.tebibytes: Capacity get() = toCapacity(CapacityUnit.TEBIBYTE)
+        /** Converts a [Number] representation of petabytes to a [Capacity]. */
+        val Number.petabytes: Capacity get() = toCapacity(CapacityUnit.PETABYTE)
 
-        /** Converts a [Long] representation of pebibytes to a [Capacity]. */
-        val Long.pebibytes: Capacity get() = toCapacity(CapacityUnit.PEBIBYTE)
-
-        /** Converts a [Long] representation of exibytes to a [Capacity]. */
-        val Long.exbibytes: Capacity get() = toCapacity(CapacityUnit.EXBIBYTE)
-
-        /** Converts a [Float] representation of kibibytes to a [Capacity]. */
-        val Float.kibibytes: Capacity get() = toCapacity(CapacityUnit.KIBIBYTE)
-
-        /** Converts a [Float] representation of mebibytes to a [Capacity]. */
-        val Float.mebibytes: Capacity get() = toCapacity(CapacityUnit.MEBIBYTE)
-
-        /** Converts a [Float] representation of gibibytes to a [Capacity]. */
-        val Float.gibibytes: Capacity get() = toCapacity(CapacityUnit.GIBIBYTE)
-
-        /** Converts a [Float] representation of tebibytes to a [Capacity]. */
-        val Float.tebibytes: Capacity get() = toCapacity(CapacityUnit.TEBIBYTE)
-
-        /** Converts a [Float] representation of pebibytes to a [Capacity]. */
-        val Float.pebibytes: Capacity get() = toCapacity(CapacityUnit.PEBIBYTE)
-
-        /** Converts a [Float] representation of exibytes to a [Capacity]. */
-        val Float.exbibytes: Capacity get() = toCapacity(CapacityUnit.EXBIBYTE)
-
-        /** Converts a [Double] representation of kibibytes to a [Capacity]. */
-        val Double.kibibytes: Capacity get() = toCapacity(CapacityUnit.KIBIBYTE)
-
-        /** Converts a [Double] representation of mebibytes to a [Capacity]. */
-        val Double.mebibytes: Capacity get() = toCapacity(CapacityUnit.MEBIBYTE)
-
-        /** Converts a [Double] representation of gibibytes to a [Capacity]. */
-        val Double.gibibytes: Capacity get() = toCapacity(CapacityUnit.GIBIBYTE)
-
-        /** Converts a [Double] representation of tebibytes to a [Capacity]. */
-        val Double.tebibytes: Capacity get() = toCapacity(CapacityUnit.TEBIBYTE)
-
-        /** Converts a [Double] representation of pebibytes to a [Capacity]. */
-        val Double.pebibytes: Capacity get() = toCapacity(CapacityUnit.PEBIBYTE)
-
-        /** Converts a [Double] representation of exbibytes to a [Capacity]. */
-        val Double.exbibytes: Capacity get() = toCapacity(CapacityUnit.EXBIBYTE)
-        //endregion
-
-        // region decimal units
-        /** Converts an [Int] representation of kilobytes to a [Capacity]. */
-        val Int.kilobytes: Capacity get() = toCapacity(CapacityUnit.KILOBYTE)
-
-        /** Converts an [Int] representation of megabytes to a [Capacity]. */
-        val Int.megabytes: Capacity get() = toCapacity(CapacityUnit.MEGABYTE)
-
-        /** Converts an [Int] representation of gigabytes to a [Capacity]. */
-        val Int.gigabytes: Capacity get() = toCapacity(CapacityUnit.GIGABYTE)
-
-        /** Converts an [Int] representation of terabytes to a [Capacity]. */
-        val Int.terabytes: Capacity get() = toCapacity(CapacityUnit.TERABYTE)
-
-        /** Converts an [Int] representation of petabytes to a [Capacity]. */
-        val Int.petabytes: Capacity get() = toCapacity(CapacityUnit.PETABYTE)
-
-        /** Converts an [Int] representation of exabytes to a [Capacity]. */
-        val Int.exabytes: Capacity get() = toCapacity(CapacityUnit.EXABYTE)
-
-        /** Converts a [Long] representation of kilobytes to a [Capacity]. */
-        val Long.kilobytes: Capacity get() = toCapacity(CapacityUnit.KILOBYTE)
-
-        /** Converts a [Long] representation of megabytes to a [Capacity]. */
-        val Long.megabytes: Capacity get() = toCapacity(CapacityUnit.MEGABYTE)
-
-        /** Converts a [Long] representation of gigabytes to a [Capacity]. */
-        val Long.gigabytes: Capacity get() = toCapacity(CapacityUnit.GIGABYTE)
-
-        /** Converts a [Long] representation of terabytes to a [Capacity]. */
-        val Long.terabytes: Capacity get() = toCapacity(CapacityUnit.TERABYTE)
-
-        /** Converts a [Long] representation of petabytes to a [Capacity]. */
-        val Long.petabytes: Capacity get() = toCapacity(CapacityUnit.PETABYTE)
-
-        /** Converts a [Long] representation of exabytes to a [Capacity]. */
-        val Long.exabytes: Capacity get() = toCapacity(CapacityUnit.EXABYTE)
-
-        /** Converts a [Float] representation of kilobytes to a [Capacity]. */
-        val Float.kilobytes: Capacity get() = toCapacity(CapacityUnit.KILOBYTE)
-
-        /** Converts a [Float] representation of megabytes to a [Capacity]. */
-        val Float.megabytes: Capacity get() = toCapacity(CapacityUnit.MEGABYTE)
-
-        /** Converts a [Float] representation of gigabytes to a [Capacity]. */
-        val Float.gigabytes: Capacity get() = toCapacity(CapacityUnit.GIGABYTE)
-
-        /** Converts a [Float] representation of terabytes to a [Capacity]. */
-        val Float.terabytes: Capacity get() = toCapacity(CapacityUnit.TERABYTE)
-
-        /** Converts a [Float] representation of petabytes to a [Capacity]. */
-        val Float.petabytes: Capacity get() = toCapacity(CapacityUnit.PETABYTE)
-
-        /** Converts a [Float] representation of exabytes to a [Capacity]. */
-        val Float.exabytes: Capacity get() = toCapacity(CapacityUnit.EXABYTE)
-
-        /** Converts a [Double] representation of kilobytes to a [Capacity]. */
-        val Double.kilobytes: Capacity get() = toCapacity(CapacityUnit.KILOBYTE)
-
-        /** Converts a [Double] representation of megabytes to a [Capacity]. */
-        val Double.megabytes: Capacity get() = toCapacity(CapacityUnit.MEGABYTE)
-
-        /** Converts a [Double] representation of gigabytes to a [Capacity]. */
-        val Double.gigabytes: Capacity get() = toCapacity(CapacityUnit.GIGABYTE)
-
-        /** Converts a [Double] representation of terabytes to a [Capacity]. */
-        val Double.terabytes: Capacity get() = toCapacity(CapacityUnit.TERABYTE)
-
-        /** Converts a [Double] representation of petabytes to a [Capacity]. */
-        val Double.petabytes: Capacity get() = toCapacity(CapacityUnit.PETABYTE)
-
-        /** Converts a [Double] representation of exabytes to a [Capacity]. */
-        val Double.exabytes: Capacity get() = toCapacity(CapacityUnit.EXABYTE)
-        //endregion
+        /** Converts a [Number] representation of exabytes to a [Capacity]. */
+        val Number.exabytes: Capacity get() = toCapacity(CapacityUnit.EXABYTE)
     }
 }

--- a/length/src/commonMain/kotlin/com/boswelja/length/Length.kt
+++ b/length/src/commonMain/kotlin/com/boswelja/length/Length.kt
@@ -59,288 +59,56 @@ value class Length(private val meters: BigDecimal): Comparable<Length> {
      * Holds static methods for creating [Length] instances from various units.
      */
     companion object {
-        /**
-         * Creates a [Length] instance from the given Int in the specified [LengthUnit].
-         */
-        fun Int.toLength(unit: LengthUnit): Length = Length(unit.toMeter(this.toBigDecimal()))
 
-        /**
-         * Creates a [Length] instance from the given Long in the specified [LengthUnit].
-         */
-        fun Long.toLength(unit: LengthUnit): Length = Length(unit.toMeter(this.toBigDecimal()))
+        fun Number.toLength(unit: LengthUnit): Length {
+            return when (this) {
+                is Byte -> Length(unit.toMeter(this.toBigDecimal()))
+                is Double -> Length(unit.toMeter(this.toBigDecimal()))
+                is Float -> Length(unit.toMeter(this.toBigDecimal()))
+                is Int -> Length(unit.toMeter(this.toBigDecimal()))
+                is Long -> Length(unit.toMeter(this.toBigDecimal()))
+                is Short -> Length(unit.toMeter(this.toBigDecimal()))
+                else -> {
+                    // Best-effort conversion
+                    Length(unit.toMeter(this.toDouble().toBigDecimal()))
+                }
+            }
+        }
 
-        /**
-         * Creates a [Length] instance from the given Float in the specified [LengthUnit].
-         */
-        fun Float.toLength(unit: LengthUnit): Length = Length(unit.toMeter(this.toBigDecimal()))
+        /** Converts the given Number to a [Length] instance in meters. */
+        val Number.meters get() = toLength(LengthUnit.METER)
 
-        /**
-         * Creates a [Length] instance from the given Double in the specified [LengthUnit].
-         */
-        fun Double.toLength(unit: LengthUnit): Length = Length(unit.toMeter(this.toBigDecimal()))
+        /** Converts the given Number to a [Length] instance in centimeters. */
+        val Number.centimeters get() = toLength(LengthUnit.CENTIMETER)
 
-        // region meters
-        /**
-         * Converts the given Int to a [Length] instance in meters.
-         */
-        val Int.meters get() = toLength(LengthUnit.METER)
+        /** Converts the given Number to a [Length] instance in kilometers. */
+        val Number.kilometers get() = toLength(LengthUnit.KILOMETER)
 
-        /**
-         * Converts the given Long to a [Length] instance in meters.
-         */
-        val Long.meters get() = toLength(LengthUnit.METER)
+        /** Converts the given Number to a [Length] instance in millimeters. */
+        val Number.millimeters get() = toLength(LengthUnit.MILLIMETER)
 
-        /**
-         * Converts the given Float to a [Length] instance in meters.
-         */
-        val Float.meters get() = toLength(LengthUnit.METER)
+        /** Converts the given Number to a [Length] instance in thous. */
+        val Number.thous get() = toLength(LengthUnit.THOU)
 
-        /**
-         * Converts the given Double to a [Length] instance in meters.
-         */
-        val Double.meters get() = toLength(LengthUnit.METER)
-        // endregion
+        /** Converts the given Number to a [Length] instance in inches. */
+        val Number.inches get() = toLength(LengthUnit.INCH)
 
-        // region centimeters
-        /**
-         * Converts the given Int to a [Length] instance in centimeters.
-         */
-        val Int.centimeters get() = toLength(LengthUnit.CENTIMETER)
+        /** Converts the given Number to a [Length] instance in feet. */
+        val Number.feet get() = toLength(LengthUnit.FOOT)
 
-        /**
-         * Converts the given Long to a [Length] instance in centimeters.
-         */
-        val Long.centimeters get() = toLength(LengthUnit.CENTIMETER)
+        /** Converts the given Number to a [Length] instance in yards. */
+        val Number.yards get() = toLength(LengthUnit.YARD)
 
-        /**
-         * Converts the given Float to a [Length] instance in centimeters.
-         */
-        val Float.centimeters get() = toLength(LengthUnit.CENTIMETER)
+        /** Converts the given Number to a [Length] instance in miles. */
+        val Number.miles get() = toLength(LengthUnit.MILE)
 
-        /**
-         * Converts the given Double to a [Length] instance in centimeters.
-         */
-        val Double.centimeters get() = toLength(LengthUnit.CENTIMETER)
-        // endregion
+        /** Converts the given Number to a [Length] instance in leagues. */
+        val Number.leagues get() = toLength(LengthUnit.LEAGUE)
 
-        // region kilometers
-        /**
-         * Converts the given Int to a [Length] instance in kilometers.
-         */
-        val Int.kilometers get() = toLength(LengthUnit.KILOMETER)
+        /** Converts the given Number to a [Length] instance in nautical miles. */
+        val Number.nauticalMiles get() = toLength(LengthUnit.NAUTICAL_MILE)
 
-        /**
-         * Converts the given Long to a [Length] instance in kilometers.
-         */
-        val Long.kilometers get() = toLength(LengthUnit.KILOMETER)
-
-        /**
-         * Converts the given Float to a [Length] instance in kilometers.
-         */
-        val Float.kilometers get() = toLength(LengthUnit.KILOMETER)
-
-        /**
-         * Converts the given Double to a [Length] instance in kilometers.
-         */
-        val Double.kilometers get() = toLength(LengthUnit.KILOMETER)
-        // endregion
-
-        // region millimeter
-        /**
-         * Converts the given Int to a [Length] instance in millimeters.
-         */
-        val Int.millimeters get() = toLength(LengthUnit.MILLIMETER)
-
-        /**
-         * Converts the given Long to a [Length] instance in millimeters.
-         */
-        val Long.millimeters get() = toLength(LengthUnit.MILLIMETER)
-
-        /**
-         * Converts the given Float to a [Length] instance in millimeters.
-         */
-        val Float.millimeters get() = toLength(LengthUnit.MILLIMETER)
-
-        /**
-         * Converts the given Double to a [Length] instance in millimeters.
-         */
-        val Double.millimeters get() = toLength(LengthUnit.MILLIMETER)
-        // endregion
-
-        // region thou
-        /**
-         * Converts the given Int to a [Length] instance in thous.
-         */
-        val Int.thous get() = toLength(LengthUnit.THOU)
-
-        /**
-         * Converts the given Long to a [Length] instance in thous.
-         */
-        val Long.thous get() = toLength(LengthUnit.THOU)
-
-        /**
-         * Converts the given Float to a [Length] instance in thous.
-         */
-        val Float.thous get() = toLength(LengthUnit.THOU)
-
-        /**
-         * Converts the given Double to a [Length] instance in thous.
-         */
-        val Double.thous get() = toLength(LengthUnit.THOU)
-        // endregion
-
-        // region inch
-        /**
-         * Converts the given Int to a [Length] instance in inches.
-         */
-        val Int.inches get() = toLength(LengthUnit.INCH)
-
-        /**
-         * Converts the given Long to a [Length] instance in inches.
-         */
-        val Long.inches get() = toLength(LengthUnit.INCH)
-
-        /**
-         * Converts the given Float to a [Length] instance in inches.
-         */
-        val Float.inches get() = toLength(LengthUnit.INCH)
-
-        /**
-         * Converts the given Double to a [Length] instance in inches.
-         */
-        val Double.inches get() = toLength(LengthUnit.INCH)
-        // endregion
-
-        // region foot
-        /**
-         * Converts the given Int to a [Length] instance in feet.
-         */
-        val Int.feet get() = toLength(LengthUnit.FOOT)
-
-        /**
-         * Converts the given Long to a [Length] instance in feet.
-         */
-        val Long.feet get() = toLength(LengthUnit.FOOT)
-
-        /**
-         * Converts the given Float to a [Length] instance in feet.
-         */
-        val Float.feet get() = toLength(LengthUnit.FOOT)
-
-        /**
-         * Converts the given Double to a [Length] instance in feet.
-         */
-        val Double.feet get() = toLength(LengthUnit.FOOT)
-        // endregion
-
-        // region yard
-        /**
-         * Converts the given Int to a [Length] instance in yards.
-         */
-        val Int.yards get() = toLength(LengthUnit.YARD)
-
-        /**
-         * Converts the given Long to a [Length] instance in yards.
-         */
-        val Long.yards get() = toLength(LengthUnit.YARD)
-
-        /**
-         * Converts the given Float to a [Length] instance in yards.
-         */
-        val Float.yards get() = toLength(LengthUnit.YARD)
-
-        /**
-         * Converts the given Double to a [Length] instance in yards.
-         */
-        val Double.yards get() = toLength(LengthUnit.YARD)
-        // endregion
-
-        // region mile
-        /**
-         * Converts the given Int to a [Length] instance in miles.
-         */
-        val Int.miles get() = toLength(LengthUnit.MILE)
-
-        /**
-         * Converts the given Long to a [Length] instance in miles.
-         */
-        val Long.miles get() = toLength(LengthUnit.MILE)
-
-        /**
-         * Converts the given Float to a [Length] instance in miles.
-         */
-        val Float.miles get() = toLength(LengthUnit.MILE)
-
-        /**
-         * Converts the given Double to a [Length] instance in miles.
-         */
-        val Double.miles get() = toLength(LengthUnit.MILE)
-        // endregion
-
-        // region league
-        /**
-         * Converts the given Int to a [Length] instance in leagues.
-         */
-        val Int.leagues get() = toLength(LengthUnit.LEAGUE)
-
-        /**
-         * Converts the given Long to a [Length] instance in leagues.
-         */
-        val Long.leagues get() = toLength(LengthUnit.LEAGUE)
-
-        /**
-         * Converts the given Float to a [Length] instance in leagues.
-         */
-        val Float.leagues get() = toLength(LengthUnit.LEAGUE)
-
-        /**
-         * Converts the given Double to a [Length] instance in leagues.
-         */
-        val Double.leagues get() = toLength(LengthUnit.LEAGUE)
-        // endregion
-
-        // region nauticalMile
-        /**
-         * Converts the given Int to a [Length] instance in nautical miles.
-         */
-        val Int.nauticalMiles get() = toLength(LengthUnit.NAUTICAL_MILE)
-
-        /**
-         * Converts the given Long to a [Length] instance in nautical miles.
-         */
-        val Long.nauticalMiles get() = toLength(LengthUnit.NAUTICAL_MILE)
-
-        /**
-         * Converts the given Float to a [Length] instance in nautical miles.
-         */
-        val Float.nauticalMiles get() = toLength(LengthUnit.NAUTICAL_MILE)
-
-        /**
-         * Converts the given Double to a [Length] instance in nautical miles.
-         */
-        val Double.nauticalMiles get() = toLength(LengthUnit.NAUTICAL_MILE)
-        // endregion
-
-        // region fathom
-        /**
-         * Converts the given Int to a [Length] instance in fathoms.
-         */
-        val Int.fathoms get() = toLength(LengthUnit.FATHOM)
-
-        /**
-         * Converts the given Long to a [Length] instance in fathoms.
-         */
-        val Long.fathoms get() = toLength(LengthUnit.FATHOM)
-
-        /**
-         * Converts the given Float to a [Length] instance in fathoms.
-         */
-        val Float.fathoms get() = toLength(LengthUnit.FATHOM)
-
-        /**
-         * Converts the given Double to a [Length] instance in fathoms.
-         */
-        val Double.fathoms get() = toLength(LengthUnit.FATHOM)
-        // endregion
+        /** Converts the given Number to a [Length] instance in fathoms. */
+        val Number.fathoms get() = toLength(LengthUnit.FATHOM)
     }
 }

--- a/length/src/commonMain/kotlin/com/boswelja/length/Length.kt
+++ b/length/src/commonMain/kotlin/com/boswelja/length/Length.kt
@@ -60,6 +60,9 @@ value class Length(private val meters: BigDecimal): Comparable<Length> {
      */
     companion object {
 
+        /**
+         * Converts a [Number] to a [Length], using the given [LengthUnit].
+         */
         fun Number.toLength(unit: LengthUnit): Length {
             return when (this) {
                 is Byte -> Length(unit.toMeter(this.toBigDecimal()))

--- a/temperature/src/commonMain/kotlin/com/boswelja/temperature/Temperature.kt
+++ b/temperature/src/commonMain/kotlin/com/boswelja/temperature/Temperature.kt
@@ -76,103 +76,34 @@ value class Temperature internal constructor(private val kelvin: BigDecimal) : C
     @Suppress("unused")
     companion object {
 
-        private fun Int.toTemperature(unit: TemperatureUnit): Temperature =
-            Temperature(unit.toKelvin(this.toBigDecimal()))
-        private fun Long.toTemperature(unit: TemperatureUnit): Temperature =
-            Temperature(unit.toKelvin(this.toBigDecimal()))
-        private fun Float.toTemperature(unit: TemperatureUnit): Temperature =
-            Temperature(unit.toKelvin(this.toBigDecimal()))
-        private fun Double.toTemperature(unit: TemperatureUnit): Temperature =
-            Temperature(unit.toKelvin(this.toBigDecimal()))
+        fun Number.toTemperature(unit: TemperatureUnit): Temperature {
+            return when (this) {
+                is Byte -> Temperature(unit.toKelvin(this.toBigDecimal()))
+                is Double -> Temperature(unit.toKelvin(this.toBigDecimal()))
+                is Float -> Temperature(unit.toKelvin(this.toBigDecimal()))
+                is Int -> Temperature(unit.toKelvin(this.toBigDecimal()))
+                is Long -> Temperature(unit.toKelvin(this.toBigDecimal()))
+                is Short -> Temperature(unit.toKelvin(this.toBigDecimal()))
+                else -> {
+                    // Best-effort conversion
+                    Temperature(unit.toKelvin(this.toDouble().toBigDecimal()))
+                }
+            }
+        }
 
-        // region kelvin
-        /** Converts an [Int] representation of kelvin to a [Temperature]. */
-        val Int.kelvin: Temperature
-            get() = toTemperature(TemperatureUnit.KELVIN)
+        /** Converts a [Number] representation of kelvin to a [Temperature]. */
+        val Number.kelvin: Temperature get() = toTemperature(TemperatureUnit.KELVIN)
 
-        /** Converts an [Long] representation of kelvin to a [Temperature]. */
-        val Long.kelvin: Temperature
-            get() = toTemperature(TemperatureUnit.KELVIN)
+        /** Converts a [Number] representation of celsius to a [Temperature]. */
+        val Number.celsius: Temperature get() = toTemperature(TemperatureUnit.CELSIUS)
 
-        /** Converts an [Float] representation of kelvin to a [Temperature]. */
-        val Float.kelvin: Temperature
-            get() = toTemperature(TemperatureUnit.KELVIN)
+        /** Converts a [Number] representation of fahrenheit to a [Temperature]. */
+        val Number.fahrenheit: Temperature get() = toTemperature(TemperatureUnit.FAHRENHEIT)
 
-        /** Converts an [Double] representation of kelvin to a [Temperature]. */
-        val Double.kelvin: Temperature
-            get() = toTemperature(TemperatureUnit.KELVIN)
-        // endregion
+        /** Converts a [Number] representation of rankine to a [Temperature]. */
+        val Number.rankine: Temperature get() = toTemperature(TemperatureUnit.RANKINE)
 
-        // region celsius
-        /** Converts an [Int] representation of celsius to a [Temperature]. */
-        val Int.celsius: Temperature
-            get() = toTemperature(TemperatureUnit.CELSIUS)
-
-        /** Converts an [Long] representation of celsius to a [Temperature]. */
-        val Long.celsius: Temperature
-            get() = toTemperature(TemperatureUnit.CELSIUS)
-
-        /** Converts an [Float] representation of celsius to a [Temperature]. */
-        val Float.celsius: Temperature
-            get() = toTemperature(TemperatureUnit.CELSIUS)
-
-        /** Converts an [Double] representation of celsius to a [Temperature]. */
-        val Double.celsius: Temperature
-            get() = toTemperature(TemperatureUnit.CELSIUS)
-        // endregion
-
-        // region fahrenheit
-        /** Converts an [Int] representation of fahrenheit to a [Temperature]. */
-        val Int.fahrenheit: Temperature
-            get() = toTemperature(TemperatureUnit.FAHRENHEIT)
-
-        /** Converts an [Long] representation of fahrenheit to a [Temperature]. */
-        val Long.fahrenheit: Temperature
-            get() = toTemperature(TemperatureUnit.FAHRENHEIT)
-
-        /** Converts an [Float] representation of fahrenheit to a [Temperature]. */
-        val Float.fahrenheit: Temperature
-            get() = toTemperature(TemperatureUnit.FAHRENHEIT)
-
-        /** Converts an [Double] representation of fahrenheit to a [Temperature]. */
-        val Double.fahrenheit: Temperature
-            get() = toTemperature(TemperatureUnit.FAHRENHEIT)
-        // endregion
-
-        // region rankine
-        /** Converts an [Int] representation of rankine to a [Temperature]. */
-        val Int.rankine: Temperature
-            get() = toTemperature(TemperatureUnit.RANKINE)
-
-        /** Converts an [Long] representation of rankine to a [Temperature]. */
-        val Long.rankine: Temperature
-            get() = toTemperature(TemperatureUnit.RANKINE)
-
-        /** Converts an [Float] representation of rankine to a [Temperature]. */
-        val Float.rankine: Temperature
-            get() = toTemperature(TemperatureUnit.RANKINE)
-
-        /** Converts an [Double] representation of rankine to a [Temperature]. */
-        val Double.rankine: Temperature
-            get() = toTemperature(TemperatureUnit.RANKINE)
-        // endregion
-
-        // region réaumur
-        /** Converts an [Int] representation of réaumur to a [Temperature]. */
-        val Int.reaumur: Temperature
-            get() = toTemperature(TemperatureUnit.REAUMUR)
-
-        /** Converts an [Long] representation of réaumur to a [Temperature]. */
-        val Long.reaumur: Temperature
-            get() = toTemperature(TemperatureUnit.REAUMUR)
-
-        /** Converts an [Float] representation of réaumur to a [Temperature]. */
-        val Float.reaumur: Temperature
-            get() = toTemperature(TemperatureUnit.REAUMUR)
-
-        /** Converts an [Double] representation of réaumur to a [Temperature]. */
-        val Double.reaumur: Temperature
-            get() = toTemperature(TemperatureUnit.REAUMUR)
-        // endregion
+        /** Converts a [Number] representation of réaumur to a [Temperature]. */
+        val Number.reaumur: Temperature get() = toTemperature(TemperatureUnit.REAUMUR)
     }
 }

--- a/temperature/src/commonMain/kotlin/com/boswelja/temperature/Temperature.kt
+++ b/temperature/src/commonMain/kotlin/com/boswelja/temperature/Temperature.kt
@@ -76,6 +76,9 @@ value class Temperature internal constructor(private val kelvin: BigDecimal) : C
     @Suppress("unused")
     companion object {
 
+        /**
+         * Converts a [Number] to a [Temperature], using the given [TemperatureUnit].
+         */
         fun Number.toTemperature(unit: TemperatureUnit): Temperature {
             return when (this) {
                 is Byte -> Temperature(unit.toKelvin(this.toBigDecimal()))


### PR DESCRIPTION
This also adds proper support for all base number types, as well as best-effort fallback for custom numbers